### PR TITLE
remove bad logic in wait_for_default_password

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -264,9 +264,6 @@ def create(vm_):
         if str(data.get('default_password', '')) == '':
             time.sleep(1)
             return False
-        if '!' not in data['default_password']:
-            time.sleep(1)
-            return False
         return data['default_password']
 
     vm_['ssh_host'] = salt.utils.cloud.wait_for_fun(


### PR DESCRIPTION
### What does this PR do?
removes bad logic in wait_for_default_password

### Previous Behavior

checking for "!" in the password results in nodes not being bootstrapped


